### PR TITLE
homematic.hmtc: Delayed sending of commands when using +/- buttons to av...

### DIFF
--- a/homematic/widget_homematic.html
+++ b/homematic/widget_homematic.html
@@ -96,7 +96,7 @@
 {% macro hmtc(id, txt, gad_actual, gad_set, gad_controlmode, gad_daytemp, gad_nighttemp, gad_window, gad_battery, gad_state, gad_txt, step, gad_valve, gad_humidity) %}
 	{% import "basic.html" as basic %}
 	{% import "icon.html" as icon %}
-	<div id="{{ uid(page, id) }}" data-widget="device.rtr" data-step="{{ step|default(0.5) }}"
+	<div id="{{ uid(page, id) }}" data-widget="device.hmtc" data-step="{{ step|default(0.5) }}"
 		class="rtr">
 		<div class="actual">
 			<div class="temp">

--- a/homematic/widget_homematic.js
+++ b/homematic/widget_homematic.js
@@ -1,1 +1,40 @@
-/** not needed*/
+// this function sets the value to the web instantly and starts a timer to send the value delayed to the server
+function deviceHmTc_setDelayed(uid, item, val) {
+    widget.update(item, val);
+    
+    obj = $('#' + uid);
+    
+    // check if there is still a timer
+    if (obj.prop("setDelayTimer")) {
+        clearTimeout(obj.prop("setDelayTimer"));
+    }
+    
+    // set timer to send the value delayed
+    obj.prop("setDelayTimer", setTimeout(function(){ 
+                                           io.write(item, val);
+                                           $('#' + uid).removeProp("setDelayTimer");
+                                         }, 3000));
+                                         
+}
+
+$(document).delegate('div[data-widget="device.hmtc"] > div > a[data-icon="minus"]', {
+    'click': function (event, response) {
+        var uid = $(this).parent().parent().attr('id');
+        var step = $('#' + uid).attr('data-step');
+        var item = $('#' + uid + 'set').attr('data-item');
+
+        var temp = (Math.round((widget.get(item) - step) * 10) / 10).toFixed(1);
+        deviceHmTc_setDelayed(uid, item, temp);
+    }
+});
+
+$(document).delegate('div[data-widget="device.hmtc"] > div > a[data-icon="plus"]', {
+    'click': function (event, response) {
+        var uid = $(this).parent().parent().attr('id');
+        var step = $('#' + uid).attr('data-step');
+        var item = $('#' + uid + 'set').attr('data-item');
+
+        var temp = (Math.round((widget.get(item) * 1 + step * 1) * 10) / 10).toFixed(1);
+        deviceHmTc_setDelayed(uid, item, temp);
+    }
+});


### PR DESCRIPTION
...oid jumping values and "command storm"

Cause of delayed processing inside of FHEM/HM we see jumping values in SV (now improved by martin but still happens). Also it helps in general to avoid "command storms". It is IMO not efficient to send 6 commands to FHEM and to radio device (plus additional ACK message) when increasing temperature from 18°C to 21°C for example by using +-button.

Please have a look into line 3 of "widget_homematic.js". The call "widget.update(item, val);" is meant to update the value on the web ONLY (without sending anything to the server). There is also "io.updateWidget" and similar stuff so I was unsure which one is best.
